### PR TITLE
fix: install missing library

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Check out all text files in UNIX format, with LF as end of line
+# Don't change this file. If you have any ideas about it, please
+# submit a separate issue about it and we'll discuss.
+
+* text=auto eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL "repository"="https://github.com/g4s8/pdd-action"
 LABEL "maintainer"="Kirill Che."
 
 # install pdd
-RUN apk add --update --no-cache ruby && \
+RUN apk add --update --no-cache ruby xz-libs && \
   mkdir /tmp/apk.cache && \
   apk add -U -t .pdd-deps --cache-dir=/tmp/apk.cache \
     "build-base" "ruby-dev" \


### PR DESCRIPTION
We install package `xz-libs` to make shared library `liblzma.so.5` available.