### PR TITLE
Fixing build error: "libmagic-dev (no such package)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --update --no-cache ruby xz-libs && \
   mkdir /tmp/apk.cache && \
   apk add -U -t .pdd-deps --cache-dir=/tmp/apk.cache \
     "build-base" "ruby-dev" \
-    "libxml2-dev" "libxslt-dev" "libmagic-dev" && \
+    "libxml2-dev" "libxslt-dev" "file-dev" && \
   gem install --no-document bundle && \
   bundle config build.nokogiri --use-system-libraries && \
   gem install --no-document json && \


### PR DESCRIPTION
I wasn't able to build the image with updated master due to Docker build error: "libmagic-dev (no such package)". This fixes building its docker image.