### PR TITLE
Fix runtime libmagic dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL "repository"="https://github.com/g4s8/pdd-action"
 LABEL "maintainer"="Kirill Che."
 
 # install pdd
-RUN apk add --update --no-cache ruby xz-libs && \
+RUN apk add --update --no-cache ruby xz-libs libmagic && \
   mkdir /tmp/apk.cache && \
   apk add -U -t .pdd-deps --cache-dir=/tmp/apk.cache \
     "build-base" "ruby-dev" \


### PR DESCRIPTION
Turns out there's runtime dependency too. Fixing error: `/usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in require Error loading shared library libmagic.so.1`

So, its `file-dev` package for builds, and `libmagic` for runtime.