### PR TITLE
Update Alpine to v3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.19
 
 LABEL "repository"="https://github.com/g4s8/pdd-action"
 LABEL "maintainer"="Kirill Che."


### PR DESCRIPTION
As of current master, `docker build .` fails with error (#9 is likely related, I can't say for sure since logs link is now expired):
```
42.09 ERROR:  Error installing bundle:
42.09 	The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.4.22. Try installing it with `gem install bundler -v 2.4.22` and then running the current command again
42.09 	bundler requires Ruby version >= 3.0.0. The current ruby version is 2.7.6.219.
------
Dockerfile:7
--------------------
   6 |     # install pdd
   7 | >>> RUN apk add --update --no-cache ruby xz-libs libmagic && \
   8 | >>>   mkdir /tmp/apk.cache && \
   9 | >>>   apk add -U -t .pdd-deps --cache-dir=/tmp/apk.cache \
  10 | >>>     "build-base" "ruby-dev" \
  11 | >>>     "libxml2-dev" "libxslt-dev" "file-dev" && \
  12 | >>>   gem install --no-document bundle && \
  13 | >>>   bundle config build.nokogiri --use-system-libraries && \
  14 | >>>   gem install --no-document json && \
  15 | >>>   gem install --no-document pdd && \
  16 | >>>   apk del .pdd-deps && \
  17 | >>>   rm -fr /tmp/apk.cache
  18 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c apk add --update --no-cache ruby xz-libs libmagic &&   mkdir /tmp/apk.cache &&   apk add -U -t .pdd-deps --cache-dir=/tmp/apk.cache     \"build-base\" \"ruby-dev\"     \"libxml2-dev\" \"libxslt-dev\" \"file-dev\" &&   gem install --no-document bundle &&   bundle config build.nokogiri --use-system-libraries &&   gem install --no-document json &&   gem install --no-document pdd &&   apk del .pdd-deps &&   rm -fr /tmp/apk.cache" did not complete successfully: exit code: 1
```
If I interpret it correctly, latest `bundle` gem is not compatible with Ruby version included in Alpine 3.13. This is not strange given it was released in January 2021.

Therefore I propose to upgrade Alpine to the latest version. Local testing shows that `docker build .` works fine after this change (Also I'm going to check if the action works)